### PR TITLE
updated v1.2.6 fix for downloading support files

### DIFF
--- a/HOW-TO-codesign.txt
+++ b/HOW-TO-codesign.txt
@@ -1,7 +1,23 @@
 Code signing is not integrated into the build script. At the Broad Institute we do something like ...
 
+
+## Java executable jar file distribution
+
+Pass in 'signjar.alias' and 'signjar.storepass' as mvn command line args. Use the jarsigner command
+to verify the signature, and the manually copy the file into a dist folder for upload as a release
+artifact.
+
+For example for the 1.2.7 release ...
+
+  mvn -Dsignjar.keystore=${HOME}/.gp_build/genepattern-codesign.jks -Dsignjar.alias=codesign -Dsignjar.storepass=********
+  jarsigner -verify target/visualizerLauncher-1.2.7-full.jar 
+  mkdirs dist
+  cp -rp target/visualizerLauncher-1.2.7-full.jar dist/visualizerLauncher-1.2.7.jar 
+
+## Mac OS X distribution
+
 1) create a zip file
-   cd target/VisualizerLauncher-1.2.1-SNAPSHOT-r2
+   cd target/visualizerLauncher-1.2.7
    zip -r VisualizerLauncher.app.zip VisualizerLauncher.app
 
 2) copy it to remote server

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>genepattern.org</groupId>
   <artifactId>visualizerLauncher</artifactId>
-  <version>1.2.6-SNAPSHOT-4</version>
+  <version>1.2.7-SNAPSHOT-1</version>
   <name>VisualizerLauncher</name>
   <url>http://maven.apache.org</url>
   

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>genepattern.org</groupId>
   <artifactId>visualizerLauncher</artifactId>
-  <version>1.2.7-SNAPSHOT-1</version>
+  <version>1.2.6-b${buildNumber}</version>
   <name>VisualizerLauncher</name>
   <url>http://maven.apache.org</url>
   
@@ -346,6 +346,23 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-exec</artifactId>
       <version>1.3</version>
+    </dependency>
+
+    <!-- 
+      Java Native Access 
+      Required for AppDirs plugin
+      See:
+        https://mvnrepository.com/artifact/net.java.dev.jna/jna 
+    -->
+    <dependency>
+      <groupId>net.java.dev.jna</groupId>
+      <artifactId>jna</artifactId>
+      <version>4.4.0</version>
+    </dependency>
+    <dependency>
+      <groupId>net.java.dev.jna</groupId>
+      <artifactId>jna-platform</artifactId>
+      <version>4.4.0</version>
     </dependency>
 
     <!--


### PR DESCRIPTION
VisualizerLauncher v1.2.6, fix for downloading support files
* fixes v1.2.5 bug which affected later versions of Mac OS X
* fixes v1.2.6-prerelease bug on Windows

* Download data files via the AppDirs framework into platform specific location:
Mac OS X: /Users//Library/Application Support/VisualizerLauncher
Windows XP: C:\Documents and Settings\Application Data\Local Settings\GenePattern\VisualizerLauncher
Windows 7: C:\Users\AppData\GenePattern\VisualizerLauncher
Unix/Linux: /home//.local/share/VisualizerLauncher
* Cache module support files
* Cache job input files